### PR TITLE
Fixed the command to execute the Artisan commands.

### DIFF
--- a/src/Support/Executor.php
+++ b/src/Support/Executor.php
@@ -23,7 +23,7 @@ class Executor
      */
     private function addPiper($command, $ttyFile)
     {
-        return "/usr/bin/script -q {$ttyFile} {$command}";
+        return '/usr/bin/script -q ' . $ttyFile . ' -c "' . $command . '"';
     }
 
     /**

--- a/src/Support/Executor.php
+++ b/src/Support/Executor.php
@@ -23,7 +23,7 @@ class Executor
      */
     private function addPiper($command, $ttyFile)
     {
-        return '/usr/bin/script -q ' . $ttyFile . ' -c "' . $command . '"';
+        return 'script -q ' . $ttyFile . ' -c "' . $command . '"';
     }
 
     /**


### PR DESCRIPTION
The command needs to be wrapped properly in order to execute. Below is the correct syntax for the typescript processor.

`script -q [PATH TO]/console.tty -c "php [PATH TO]/artisan [ARTISAN COMMAND]"`